### PR TITLE
fix package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-video-controls",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/vue-video-controls.js",
   "scripts": {
     "test": "test"
   },


### PR DESCRIPTION
It's needed because if you use eslint, it will notify the module isn't found.
Related to the main script path